### PR TITLE
Front page content draft

### DIFF
--- a/new_front_page_mockup.md
+++ b/new_front_page_mockup.md
@@ -1,0 +1,75 @@
+{logo}
+
+// 25 word message describing Operate First, something like:
+
+**Operate First is a concept to incorporate operational experience into software projects.**
+
+[CTAs]
+How it works →
+Bring your code →
+Read more → “How to open source cloud operations” by Marcel Hild
+
+[fold]-----------------------------------------------------------------------------------------------------------------
+
+// some kind of graphic to explain:
+
+Operate First Community of Practice: the community that practices operating first, sets the guidance for the method, and continually improves upon that method
+
+An Operate First Community Production Cloud: an environment in which you can operate first
+
+
+**Vision or motivation**
+
+// description of Operate First motivation and its impacts on developers, operators, and final product
+
+While open source has made software widely available, it has also exposed another barrier to entry: the ability to operate software in production.
+Proprietary services for operations undermine the open source model, so we must now shift our focus to open sourcing operations.
+
+In doing so, developers and operators collaborate to apply the operational considerations of a project right back into that project’s code.
+
+**Interested? Learn how Operate First can help you**
+
+<table>
+  <tr>
+   <td>user 1
+<p>
+// a sentence
+<p>
+// CTA →
+   </td>
+   <td>user 2
+<p>
+// a sentence
+<p>
+// CTA →
+   </td>
+   <td>user 3
+<p>
+// a sentence
+<p>
+// CTA →
+   </td>
+   <td>user 4
+<p>
+// a sentence
+<p>
+// CTA →
+   </td>
+  </tr>
+</table>
+
+**Early Success Story**
+
+Hear from the experience of an Operate First member on how our method ultimately proved crucial to their success.
+
+[CTA] Learn more →
+
+**Get Involved**
+
+// describe and link various ways to get connected
+*   slack
+*   mailing lists
+    *   general mailing list ([Operate-first Info Page](https://listman.redhat.com/mailman/listinfo/operate-first))
+    *   MOC’s operate first mailing list ([Operate-first-users Info Page](https://mail.massopen.cloud/mailman/listinfo/operate-first-users))
+    *   open infra labs mailing list ([Openinfralabs Info Page](http://lists.opendev.org/cgi-bin/mailman/listinfo/openinfralabs))
+*   github links for operate first, open infra labs, anything else useful


### PR DESCRIPTION
This pr adds a file containing draft content for a new front page for operate-first.cloud. The new_front_page_mockup.md file is a simple, preliminary draft of ideas for new organization and content. Opinions, ideas, and contributions are welcome.

Resolves https://github.com/operate-first/community/issues/38