### PR TITLE
Fixed bad manual merge, new content, is useful [squashed commits 3 in…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,0 @@
-This is a placeholder file.
-In this file will go instructions on how to contribute to this repository.
-
-However, the intention is that this type of one-off file will be replaced by the Community Handbook.

--- a/README.md
+++ b/README.md
@@ -2,68 +2,71 @@
 
 This repository is used by all members of the Operate First community for managing the ongoing support and sustaining the community of persons and organizations around this initiative.
 
-Bootstrapping ...
+## Bootstrapping
+
+This repository is the home to an initiative to bring a formal _community architecture_ process to the Operate First efforts. This initiative is in the beginning stages (bootstrapping) of defining and performing this work.
 
 # Contributing
 
 All are welcome to contribute to this repository and our efforts.
 
-Details can be found in the CONTRIBUTING.md file.
+Details beyond this README file can be found in the `contributing.md` file.
 
-# Processes
+## Processes
 
-Until there is a Community Handbook to gather this content within, all of the processes for interacting with this repository and work around it are contained in this section.
+Until there is a Community Handbook to gather this content within, all of the processes for interacting with this repository and work around it are contained in this section, or held in the `contributing.md` file.
 
-## Reviewing pull requests for this repository
+### Reviewing pull requests for this repository
 
-All commits to this repository should use a pull request process for most changes.
+All commits to this repository should use a [pull request process](https://github.com/operate-first/blueprint/blob/main/docs/adr/0016-pr-review.md#process) for most changes.
 This means under normal conditions, no one should commit directly to the repo.
 Instead, they branch or fork the repo, make changes in the branch/fork, and then make a pull request against the main repo.
 
-We do not need a stringent review process for accepting pull requests into this repo because it is for project work that appears in its finished form in locations such as https://operate-first.cloud, https://twitter.com/operate-first, the Operate First community mailing list, and so forth.
+Because content in this repo is not in its final form, we do not need as stringent a review process for accepting pull requests into this repo. This repo is for project work that appears in its finished form in locations such as https://operate-first.cloud, https://twitter.com/operate-first, the Operate First [community mailing list](https://listman.redhat.com/mailman/listinfo/operate-first), and so forth.
 This is generally not a final-form location, and we are often dumping in partially completed work to finish here openly.
 
 However, we want to follow the PR process for several reason:
-it matches practices with the rest of the project;
-it makes sure commits are clean;
-it keeps more people involved and aware of what is happening;
-it helps us keep in the habit.
+* it matches practices with the rest of the project;
+* it makes sure commits are clean;
+* it keeps more people involved and aware of what is happening;
+* it helps us keep in the habit.
 
 Early drafts tend to be collaborated on in Google Docs, via email, or on one's own until there is enough material to create a MarkDown file and generate a pull request.
 
 We then work collaboratively in the PR review process to update the content for inclusion in the repo.
 Sometimes we just touch the work briefly, sometimes we use the PR to edit heavily.
 
-Once in the repo, we use the PR process to ensure commits are clean and things are double-checked, but it is expected that many of these PRs are going to be reviewed and passed pro-forma.
+Once in the repo, we use the PR process to ensure commits are clean and things are double-checked.
+With content, the initial commits are not required to adhere to any style guide.
+In many cases, that is done during a later review and copyedit pass, to keep the focus on the accuracy and clarity of the content before going to the efforts to make changes for style and final grammar.
 
-Supported commands are listed [here](https://prow.operate-first.cloud/command-help). We have also enabled Prow to consume on-repository configuration files. You can specify your config in [`.prow.yaml`](.prow.yaml). Additional centralized configuration can be found in the [thoth-application repository](https://github.com/thoth-station/thoth-application/tree/master/prow/overlays/cnv-prod).
+### Prow CI
+This repository uses Prow for CI.
+This section is here as a reminder to consider any custom configurations for the `.prow.yaml` file.
 
-## Pre-commit
+Prow is a CI provider developed for Kubernetes needs.
+It provides chat-ops management of pull requests, issues, and declarative management for labels, branches, and many more.
 
-* `area/contributor` Indicates an issue/PR is related to a project platform contributor.
-* `area/user`: Indicates an issue/PR is related to a project platform user.
-* `kind/experience:` Indicates an issue/PR is related to human interaction and experience of the platform, project, et al.
-* `kind/governance`: Indicates an issue/PR is related to governance.
-* `kind/handbook`: Indicates an issue/PR is related to a handbook.
-* `kind/marketing`: Indicates an issue/PR is related to marketing.
-* `kind/metrics`: Indicates an issue/PR is related to metrics.
-* `kind/news`: Indicates an issue/PR is related to project news and outreach.
-* `kind/onboarding`: Indicates an issue/PR is related to onboarding.
-* `kind/website`: Indicates an issue/PR is related to project web presence.
+We host our own deployment of Prow in Operate First available at [https://prow.operate-first.cloud/](https://prow.operate-first.cloud/).
 
-### Examples of labels in use
+Supported commands are listed [here](https://prow.operate-first.cloud/command-help).
+We have also enabled Prow to consume on-repository configuration files.
+You can specify your config in [`.prow.yaml`](.prow.yaml).
+Additional centralized configuration can be found in the [thoth-application repository](https://github.com/thoth-station/thoth-application/tree/master/prow/overlays/cnv-prod).
 
-* A PR that signals the completion of an important Epic worthy of making some noise about and including in a newsletter can be labeled `area/community`, `kind/news`, and `kind/marketing`.
-* An issue is related to the experience of users joining the project to become contributors is labeled `area/community`, `area/user`, `area/contributor`, `kind/experience`, and `kind/onboarding`.
-* A write-up on how to setup a clone of a repository for doing work intended to be contributed to the community would be labeled `area/contributor`, `kind/documentation`, `kind/onboarding`, and `kind/handbook`.
-=======
-We do not need as stringent a review process for accepting pull requests into this repo because it is for project work that appears in its finished form in locations such as https://operate-first.cloud, https://twitter.com/operate-first, the Operate First community mailing list, and so forth. This is generally not a final-form location, and we are often dumping in partially completed work to finish here openly.
+### Pre-commit
+This repository uses the project-wide pre-commit hooks.
 
-Early drafts tend to be collaborated on in Google Docs, via email, or on one's own until there is enough material to create a MarkDown file and generate a pull request. We can then work collaboratively in the PR review process to update the content for inclusion in the repo. Sometimes we just touch the work briefly, sometimes we use the PR to edit heavily. Once in the repo, we use the PR process to ensure commits are clean and things are double-checked, but it is expected that many of these PRs are going to be reviewed and passed pro-forma.
+We enable yamllint hook by default, since most of our repositories use yaml files extensively.
+Default configuration for this hook is located at [`yamllint-config.yaml`](yamllint-config.yaml).
+
+To install and enable pre-commit locally please follow the instructions [here](https://pre-commit.com/#quick-start).
+
+It is advised for all contributors to enable pre-commit git hook via `pre-commit install` after cloning any repo within Operate First.
 
 ## Using labels
 
-There are a new set of labels available project wide:
+There are a new set of labels available for the whole Operate First contributor community:
 
 * `area/community`: Indicates an issue/PR is related to the overall community.
 * `area/contributor` Indicates an issue/PR is related to a project platform contributor.
@@ -77,8 +80,13 @@ There are a new set of labels available project wide:
 * `kind/onboarding`: Indicates an issue/PR is related to onboarding.
 * `kind/website`: Indicates an issue/PR is related to project web presence.
 
- Examples of use:
+### Examples of labels in use
 
- * A PR that signals the completion of an important Epic worthy of making some noise about and including in a newsletter can be labeled `area/community`, `kind/news`, and `kind/marketing`.
- * An issue is related to the experience of users joining the project to become contributors is labeled `area/community`, `area/user`, `area/contributor`, `kind/experience`, and `kind/onboarding`.
- * A write-up on how to setup a clone of a repository for doing work intended to be contributed to the community would be labeled `area/contributor`, `kind/documentation`, `kind/onboarding`, and `kind/handbook`.
+These labels are common for all projects in the [Operate First GitHub repository](https://github.com/operate-first).
+This way, wherever you are in the project repos, you can mark a pull request or an issue with these labels to assist in community management.
+
+Non-specific examples:
+
+* A PR that signals the completion of an important Epic worthy of making some noise about and including in a newsletter can be labeled `area/community`, `kind/news`, and `kind/marketing`.
+* An issue is related to the experience of users joining the project to become contributors is labeled `area/community`, `area/user`, `area/contributor`, `kind/experience`, and `kind/onboarding`.
+* A write-up on how to setup a clone of a repository for doing work intended to be contributed to the community would be labeled `area/contributor`, `kind/documentation`, `kind/onboarding`, and `kind/handbook`.

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,9 @@
+This is a placeholder file.
+In this file will go instructions on how to contribute to this repository.
+
+However, the intention is that this type of one-off file will be replaced by the Community Handbook.
+
+## Items to address
+
+Adhere to style guide (that Community Handbook should be using) to have a separate line for each sentence in a paragraph of MarkDown.
+This greatly improves readability of patches/diffs and helps during the pull request review process.


### PR DESCRIPTION
…to 1]

- Had done a poor job with a manual merge conflict earlier, which was easier to work out with realtime rendering of the MarkDown on this pass
- Added content around contributing and process, especially our lightweight review process for PRs
- Until Community Handbook holds it, the location for the how-to for these new labels is:  https://github.com/operate-first/community#examples-of-labels-in-use
- Content around using Prow etc. could move to contributing.md until we can reference a canonical location in the Community Handbook.
- Noteworthy:  this is a bootstrapping effort for at least the next few weeks still, I'm leaving that marker in the README nice and prominent to remind us to get this _out of_ bootstrapping stage ASAP.

Signed-off by: Karsten Wade <kwade@redhat.com> <quaid@iquaid.org>

Renaming to project standard file name
- Per https://github.com/operate-first/blueprint/blob/main/docs/adr/0016-pr-review.md#context-and-problem-statement
Signed-off by: Karsten Wade <kwade@redhat.com> <quaid@iquaid.org>

Holding place until Community Handbook ready to receive
Signed-off by: Karsten Wade <kwade@redhat.com> <quaid@iquaid.org>