### PR TITLE
Added the Curator contributors to the internal_contributors var

### DIFF
--- a/metrics/community_metrics.ipynb
+++ b/metrics/community_metrics.ipynb
@@ -632,8 +632,8 @@
    "outputs": [],
    "source": [
     "# Identify the list of internal contributors\n",
-    "internal_contributors = ['Aakanksha Duggal','Alice Saparov','Anand Sanmukhani','Bill Burns','Christoph Görn','Francesco Murdaca','Fridolín Pokorný','Harshad Reddy Nalla','Heidi Picher Dempsey','Hema Veeradhi',\n",
-    " 'Humair','Ilana Polonsky','Isabel Zimmerman','Karanraj Chauhan','Karsten Wade','Lars Kellogg-Stedman','Marcel Hild','Margaret Haley','Michael Clifford','Michal Drla','Oindrilla Chatterjee','Operate First','Shrey','Surya Prakash Pathak','Thoth Bot','Tom Coufal']"
+    "internal_contributors = ['Aakanksha Duggal','Alice Saparov','Anand Sanmukhani','Bill Burns','Christoph Görn','Francesco Murdaca','Fridolín Pokorný','Gagan Kumar','Harshad Reddy Nalla','Heidi Picher Dempsey','Hema Veeradhi',\n",
+    " 'Humair','Isabel Zimmerman','Karanraj Chauhan','Karsten Wade','Lars Kellogg-Stedman','LeihaoChen','Marcel Hild','Margaret Haley','Michael Clifford','Michal Drla','Oindrilla Chatterjee','Operate First','Shrey','Surbhi Kanthed','Surya Prakash Pathak','Thoth Bot','Tom Coufal']"
    ]
   },
   {


### PR DESCRIPTION
The PR has the following changes:
- Addition of users Gagan Kumar, LeihaoChen and Surbhi Kanthed. These users are Red Hatters and work on the Curator project.
- Removal of user Ilana Polonsky. Ilana has left Red Hat.  