### PR TITLE
WIP add a subproject for airgapped operations of ODH

### DIFF
--- a/sig-operations/subprojects/airgapped-ops/OWNERS
+++ b/sig-operations/subprojects/airgapped-ops/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - goern
+  - harshad16
+  - HumairAK
+  - rbo
+reviewers:
+  - codificat
+  - mayaCostantini
+  - 4n4nd

--- a/sigs.yaml
+++ b/sigs.yaml
@@ -1,34 +1,50 @@
 sigs:
-- dir: sig-operations
-  name: Operations
-  mission_statement: >
-    The goal of this SIG is to enable management and operations for hardware and platform
-    tooling within the Operate First Community Cloud (op1st)
+  - dir: sig-operations
+    name: Operations
+    mission_statement: >
+      The goal of this SIG is to enable management and operations for hardware and platform
+      tooling within the Operate First Community Cloud (op1st)
 
-  charter_link: charter.md
-  label: operations
-  leadership:
-    chairs:
-    - github: HumairAK
-      name: Humair Khan
-      company: Red Hat
-    - github: larsks
-      name: Lars Kellogg-Stedman
-      company: Red Hat
-  meetings:
-  - description: SIG Operations meeting
-    day: Tuesday
-    time: "10:00"
-    tz: EST
-    frequency: weekly
-    url: tbd
-  contact:
-    slack: operations
-    mailing_list: community@lists.operate-first.cloud
-  subprojects:
-  - name: tbd
-    owners:
-    - https://raw.githubusercontent.com/tbc/tbc/main/tbc/OWNERS
+    charter_link: charter.md
+    label: operations
+    leadership:
+      chairs:
+        - github: HumairAK
+          name: Humair Khan
+          company: Red Hat
+        - github: larsks
+          name: Lars Kellogg-Stedman
+          company: Red Hat
+    meetings:
+      - description: SIG Operations meeting
+        day: Tuesday
+        time: "10:00"
+        tz: EST
+        frequency: weekly
+        url: tbd
+    contact:
+      slack: operations
+      mailing_list: community@lists.operate-first.cloud
+    subprojects:
+      - name: airgapped-ops
+        description: >
+          This is creating all the artifacts required for an aiggapped deployment of Open Data Hub
+          within the Operate First Community Cloud (op1st)
+        owners:
+          - https://raw.githubusercontent.com/operate-first/community/main/sig-operations/subprojects/airgapped-ops/OWNERS
+        meetings:
+          - description: Cluster Ops Meeting
+            day: Tuesday
+            time: "8:30"
+            tz: EST
+            frequency: Weekly
+            url: meet.google.com/wxh-pizv-vwt
+          - description: Cluster Ops meeting
+            day: Thursday
+            time: "8:30"
+            tz: EST
+            frequency: Weekly
+            url: meet.google.com/wxh-pizv-vwt
 workinggroups: []
 usergroups: []
 committees: []


### PR DESCRIPTION
This is a proposed subproject to investigate how to deploy and operate ODH in airgapped environments, there has been some work on this topic, but it needs review and structure. The intention it to contribute back to ODH community and involve business partners too.

I think this depends on #130 therefor I have not regenerated any .md

Signed-off-by: Christoph Görn <goern@redhat.com>
