### PR TITLE
updating pre-commit to use https instead of git urls

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 ---
 repos:
-  - repo: git://github.com/Lucas-C/pre-commit-hooks
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.9
     hooks:
       - id: remove-tabs
 
-  - repo: git://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.3.0
     hooks:
       - id: trailing-whitespace


### PR DESCRIPTION
Similar to: https://github.com/thoth-station/thoth-application/issues/2111

connecting over unencrypted git protocol has been deprecated, switching to https. For more info see here: https://github.blog/2021-09-01-improving-git-protocol-security-github/