### PR TITLE
Directory structure for new working groups

### DIFF
--- a/sig-community/wg-contrib_x-docs/meeting-notes/yyyymmdd-meeting-notes-template.md
+++ b/sig-community/wg-contrib_x-docs/meeting-notes/yyyymmdd-meeting-notes-template.md
@@ -1,0 +1,24 @@
+# Formal name of group, e.g. April Fools subproject
+
+## 2022-04-01 Kickoff planning
+
+Attendees:
+- Firstname Lastname @github-nick (Organizational affiliation)
+- Firstname Lastname @github-nick (Organizational affiliation)
+- Firstname Lastname @github-nick (Organizational affiliation)
+
+Agenda and Notes:
+1. First agenda item
+  1. Notes made during meeting about agenda item
+1. Second agenda item
+  1. Notes made during meeting about agenda item
+  1. ACTION: Action to take on this item with @githubnick1 @githubnick2 etc.
+  1. Subagenda item
+    1. Notes made during meeting about agenda item
+      1. ACTION: Action to take on this item with @githubnick1 @githubnick2 etc.
+1. Third agenda items
+  1. Notes made during meeting about agenda item
+
+Actions:
+* Bulleted list pulling out all actions from the notes into one list
+* Format loose but must include one or more people who are responsible.

--- a/sig-community/wg-website-updates/meeting-notes/yyyymmdd-meeting-notes-template.md
+++ b/sig-community/wg-website-updates/meeting-notes/yyyymmdd-meeting-notes-template.md
@@ -1,0 +1,24 @@
+# Formal name of group, e.g. April Fools subproject
+
+## 2022-04-01 Kickoff planning
+
+Attendees:
+- Firstname Lastname @github-nick (Organizational affiliation)
+- Firstname Lastname @github-nick (Organizational affiliation)
+- Firstname Lastname @github-nick (Organizational affiliation)
+
+Agenda and Notes:
+1. First agenda item
+  1. Notes made during meeting about agenda item
+1. Second agenda item
+  1. Notes made during meeting about agenda item
+  1. ACTION: Action to take on this item with @githubnick1 @githubnick2 etc.
+  1. Subagenda item
+    1. Notes made during meeting about agenda item
+      1. ACTION: Action to take on this item with @githubnick1 @githubnick2 etc.
+1. Third agenda items
+  1. Notes made during meeting about agenda item
+
+Actions:
+* Bulleted list pulling out all actions from the notes into one list
+* Format loose but must include one or more people who are responsible.


### PR DESCRIPTION
- includes current template for meeting-notes
  - we can look at how best to maintain and disseminate a template
  - this one is just copied (via CLI) from
    github/operate-first/community/sig-community/meeting-notes/yyyymmdd-meeting-notes-template.md

Signed-off-by: Karsten Wade <kwade@redhat.com>