### PR TITLE
open-source-services.md: Use word 'dependencies' for clarity

### DIFF
--- a/open-source-services.md
+++ b/open-source-services.md
@@ -73,7 +73,7 @@ However, if a typical team member operates their own instance of the service in 
 It is a powerful, laudable goal for others to be able to operate an Open Source service, either by operating an instance on their own, or participating in operations of a common instance.
 [Operate First](https://www.operate-first.cloud/) is a project that enables this, and even provides infrastructure.
 
-### Q: Must all requirements for a service be Open Source too?
+### Q: Must all dependencies for a service be Open Source too?
 
 **A:** It is _not required_ that all dependencies of a service are Open Source, or have Open Source alternatives.
 For example, a service may interact with a proprietary authentication system, or run on a proprietary platform.


### PR DESCRIPTION
Use the word 'dependencies' instead of 'requirements' for clarity
in the FAQ. What we really mean here is the things that the Service
depends on. The use of the word 'requirements' is already significantly
overloaded here, by referring to the #1 and #2 requirements themselves.

In addition, others have confused these with /product requirements/ or
/testing requirements/. None of these are implied here.

Use of the word 'depndencies' makes this much clearer.