### PR TITLE
Added links to Slack and Operate First community calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ All are welcome to contribute to this repository and our efforts.
 
 Details beyond this README file can be found in the `contributing.md` file.
 
+If you are interested in being involved in community projects and meetings make sure to join our [Slack](https://join.slack.com/t/operatefirst/shared_invite/zt-o2gn4wn8-O39g7sthTAuPCvaCNRnLww) and our [Operate First Community Google calender](https://calendar.google.com/calendar/u/0/embed?src=operate.first.community@gmail.com&ctz=America/New_York) to know when we meet.
 ## Processes
 
 Until there is a Community Handbook to gather this content within, all of the processes for interacting with this repository and work around it are contained in this section, or held in the `contributing.md` file.

--- a/open-source-services.md
+++ b/open-source-services.md
@@ -87,5 +87,5 @@ The requirements together serve to enable others to change the service code so t
 If your project grows bigger, and has many participants, then forming a community with the typical components (communication venues, code of conduct, governance, etc.) is _recommended_, and brings significant further Open Source benefits.
 
 Among other things, having a community means sharing your documentation, issues, and a roadmap. It also means conducting most planning conversations about the service in the open, and not limiting participation to your team.
-This is how you gain the advantages of the Open innovation process, where minds beyond your team can help work through problems and create solutions 
+This is how you gain the advantages of the Open innovation process, where minds beyond your team can help work through problems and create solutions
 Without these things, your community interaction will be more painful as crossing the boundary between community and Red Hat private has a high context switching cost.


### PR DESCRIPTION
## Description:
This PR adds links to our community page on how to be involved in meetings and discussions. 
- Slack link
- Google calendar link