### PR TITLE
Notes from 18 July meeting, markdown fixes

### DIFF
--- a/sig-community/wg-contrib_x-docs/meeting-notes/20220618-meeting-notes.md
+++ b/sig-community/wg-contrib_x-docs/meeting-notes/20220618-meeting-notes.md
@@ -1,0 +1,14 @@
+# 2022-07-18
+
+## Attendees
+- Karsten Wade @quaid 
+- Thorsten Schwesig @schwesig
+
+## Agenda and Notes:
+1. at the end of every meeting (during the meeting), the minutes will be merged via PR (approximately five minutes before the end):
+    1. tagging the people who participated
+    1. if sth needs to be corrected/added/updated, this can be done by a later PR
+1. Describe the process first, find an automated solution later
+    1. If you do sth three times exactly the same, automate it
+    1. If you didn't do it at least three times exactly the same, don't automate it
+1. `Curate and/or create-a-doc:` - a title for an issue where the CTA is to look for sufficient documentation to point at, then wrap it with whatever custom Operate First differences are relevant. E.g., how to make a PR can point to a chosen (curated) GitHub doc resource, then tell the differences or particulars for following those steps in the Op1st environment.


### PR DESCRIPTION
Had to adjust the markdown for the numbered list as apparently GitHub flavored
markdown wants the plain numbering, but HackMd doesn't do that by default.