### PR TITLE
Evolving to Docs WG via this charter

### DIFF
--- a/sig-community/docs-wg/charter.md
+++ b/sig-community/docs-wg/charter.md
@@ -1,0 +1,36 @@
+# Documentation Working Group (Docs WG)
+**Formerly _Contributor Experience Documentation Working Group (Contrib_X Docs WG)_**
+
+This working group has expanded to encompass discussions around all areas of documentation, with the goal of exiting this working group into a Docs SIG.
+At the same time, the Docs WG is completing the original mission of improving documentation for new users and contributors.
+
+## Scope
+
+**Improving documentation for new users and contributors**
+This was the original mission of the _Contributor Experience Documentation Working Group (Contrib_X Docs WG)_.
+This remains a primary goal of the working group, but does not need to be finished for a Docs SIG to form.
+In such a case, a Docs SIG would take on the work being done by the WG and continue it as a WG or formalize it as a subproject.
+
+**Planning and exiting to the Docs WIG**
+Work output should be a plan to form the Docs SIG out of the working group.
+Any documentation identified as needed but does not fit into the SIG creation or the new user/contributor experience scopes is left for the Docs SIG to discuss and decide.
+
+## In scope
+
+* Discussions around the interrelation of all documentation.
+* Formation of the key "User and Contributor Handbook".
+* Strategy and plans to form a Docs SIG.
+* Promotion of documentation creation and improvement across the project.
+* Resolving the gaps in documentation for users/contributors who are new to the platform.
+
+### Out of scope
+
+* Scoping, creating, or managing Operations Documentation; that scope discussion is left for the Docs SIG.
+* Scoping and creating new content for any persona state beyond "new"; that is a scope left for the Docs SIG.
+* Scoping and creating new content for any advanced user/contributor states; that is a scope left for the Docs SIG.
+
+## Stakeholders
+
+* Contributors, and by extension contributors' organizations
+* All user personas
+


### PR DESCRIPTION
The Contributor Experience Documentation WG (Contrib_X Docs WG) is changing to become the Docs WG.

This pull request is a draft of a new charter for discussion, and as part of the promotion of the WG scope and name change.